### PR TITLE
Add simple Binance futures trading bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # testCodex
-test my Codex 
+
+This repository contains a simple example script for automatically trading Bitcoin futures on Binance using Python's built-in libraries.
+
+## trade_bot.py
+
+`trade_bot.py` implements a minimal trading bot that:
+
+1. Fetches the current BTC price from Binance futures.
+2. Retrieves a basic sentiment indicator from the CoinDesk price API.
+3. Decides whether to go long or short based on this sentiment.
+4. Places a market order and sets stop loss and take profit orders.
+
+API credentials must be supplied via the environment variables `BINANCE_API_KEY` and `BINANCE_API_SECRET` before running the script.
+
+Run the bot with:
+
+```bash
+python trade_bot.py
+```
+
+Note that this is a demonstration and does not include advanced error handling or trading logic. Use at your own risk.

--- a/trade_bot.py
+++ b/trade_bot.py
@@ -1,0 +1,127 @@
+import os
+import time
+import hmac
+import hashlib
+import urllib.request
+import urllib.parse
+import json
+
+BASE_URL = "https://fapi.binance.com"
+
+API_KEY = os.getenv("BINANCE_API_KEY", "")
+API_SECRET = os.getenv("BINANCE_API_SECRET", "")
+
+
+def send_signed_request(method, path, params=None):
+    if params is None:
+        params = {}
+    params['timestamp'] = int(time.time() * 1000)
+    query_string = urllib.parse.urlencode(params)
+    signature = hmac.new(API_SECRET.encode('utf-8'), query_string.encode('utf-8'), hashlib.sha256).hexdigest()
+    url = f"{BASE_URL}{path}?{query_string}&signature={signature}"
+    req = urllib.request.Request(url, method=method)
+    req.add_header("X-MBX-APIKEY", API_KEY)
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+def send_public_request(method, path, params=None):
+    if params:
+        query_string = urllib.parse.urlencode(params)
+        url = f"{BASE_URL}{path}?{query_string}"
+    else:
+        url = f"{BASE_URL}{path}"
+    req = urllib.request.Request(url, method=method)
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+def get_market_price(symbol):
+    data = send_public_request("GET", "/fapi/v1/ticker/price", {"symbol": symbol})
+    return float(data['price'])
+
+
+def fetch_economic_sentiment():
+    url = "https://api.coindesk.com/v1/bpi/currentprice.json"
+    try:
+        with urllib.request.urlopen(url) as resp:
+            data = json.loads(resp.read())
+        # very naive sentiment example
+        usd_rate = float(data['bpi']['USD']['rate'].replace(',', ''))
+        if usd_rate > 0:
+            return "positive"
+        return "neutral"
+    except Exception:
+        return "neutral"
+
+
+def analyze(price, sentiment):
+    if sentiment == "positive":
+        return "BUY"
+    elif sentiment == "negative":
+        return "SELL"
+    else:
+        return None
+
+
+def place_market_order(symbol, side, quantity):
+    params = {
+        "symbol": symbol,
+        "side": side,
+        "type": "MARKET",
+        "quantity": quantity,
+    }
+    return send_signed_request("POST", "/fapi/v1/order", params)
+
+
+def place_stop_order(symbol, side, stop_price, order_type):
+    params = {
+        "symbol": symbol,
+        "side": side,
+        "type": order_type,
+        "stopPrice": stop_price,
+        "closePosition": True,
+        "workingType": "CONTRACT_PRICE",
+    }
+    return send_signed_request("POST", "/fapi/v1/order", params)
+
+
+def wait_for_order(symbol, order_id, timeout=60):
+    end_time = time.time() + timeout
+    while time.time() < end_time:
+        params = {"symbol": symbol, "orderId": order_id}
+        data = send_signed_request("GET", "/fapi/v1/order", params)
+        if data.get("status") in ("FILLED", "CANCELED", "REJECTED", "EXPIRED"):
+            return data.get("status")
+        time.sleep(1)
+    return "UNKNOWN"
+
+
+def main():
+    symbol = "BTCUSDT"
+    quantity = 0.001
+    price = get_market_price(symbol)
+    sentiment = fetch_economic_sentiment()
+    side = analyze(price, sentiment)
+    if not side:
+        print("No clear signal. Skipping trade.")
+        return
+    stop = price * (0.99 if side == "BUY" else 1.01)
+    take = price * (1.01 if side == "BUY" else 0.99)
+
+    order = place_market_order(symbol, side, quantity)
+    order_id = order.get("orderId")
+    if not order_id:
+        print("Order failed:", order)
+        return
+
+    opposite = "SELL" if side == "BUY" else "BUY"
+    place_stop_order(symbol, opposite, stop, "STOP_MARKET")
+    place_stop_order(symbol, opposite, take, "TAKE_PROFIT_MARKET")
+
+    status = wait_for_order(symbol, order_id)
+    print("Final order status:", status)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `trade_bot.py` showcasing a basic automatic trading bot using Binance Futures API
- document how to run the bot and supply API credentials in `README.md`

## Testing
- `python trade_bot.py` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_684891363fd48322924489c33d2fc044