### PR TITLE
Add strategy script and sync indicator

### DIFF
--- a/strategy.pine
+++ b/strategy.pine
@@ -1,13 +1,26 @@
 //@version=6
 // ╔════════════════════════════════════════════════════════════════════╗
-// ║  BTC‑2 • Risk‑Sizing + Dynamic‑SL • limit‑entry + cooldown (IND)  ║
-// ║  Индикатор на основе стратегии                                   ║
+// ║  BTC‑2 • Risk‑Sizing + Dynamic‑SL • limit‑entry + cooldown        ║
+// ║  ▸ лимит = open сигнального бара; заявка живёт N баров            ║
+// ║  ▸ SL% = max(BaseSL , a + b·ATR);  TP% = SL% × tpMult(long/short) ║
+// ║  ▸ qty рассчитывается от риска + проверка маржи                   ║
+// ║  ▸ alert():                                                       ║
+// ║        LIMIT‑LONG  | …  – лимитка Long выставлена                 ║
+// ║        LIMIT‑SHORT | …  – лимитка Short выставлена                ║
+// ║        ENTRY‑LONG  | …  – позиция Long открылась                  ║
+// ║        ENTRY‑SHORT | …  – позиция Short открылась                 ║
 // ╚════════════════════════════════════════════════════════════════════╝
-indicator(
-     title               = "BTC2 • Risk‑Sizing + Dyn‑SL (limit+cooldown) [IND]",
-     shorttitle          = "BTC2_RISK_DSL_IND",
+strategy(
+     title               = "BTC2 • Risk‑Sizing + Dyn‑SL (limit+cooldown)",
+     shorttitle          = "BTC2_RISK_DSL",
      overlay             = true,
-     max_labels_count    = 500)
+     default_qty_type    = strategy.fixed,
+     default_qty_value   = 0,
+     initial_capital     = 30000,
+     currency            = currency.USDT,
+     process_orders_on_close = true,
+     max_labels_count    = 500,
+     calc_on_every_tick  = false)
 
 // ───────── 1.  Риск и стоп‑параметры ────────────────────────────────── 
 riskPerc        = input.float(1.0 , "Risk per trade (%)", step=0.1)
@@ -27,11 +40,7 @@ cooldownBars    = input.int (10 , "Cooldown bars after exit",  1)
 colorBars       = input.bool(true , "Color bars?")
 showMark        = input.bool(true , "Show L/S markers?")
 
-// initial equity for qty calc
-initEquity      = input.float(30000, "Initial equity")
-var float equity = initEquity
-
-// ───────── 2.  Фильтры и параметры индикаторов (как в стратегии) ───
+// ───────── 2.  Фильтры и параметры индикаторов (как в индикаторе) ───
 emaLenDaily       = input.int  (200, "EMA (Daily)")
 chopLengthDaily   = input.int  (14 , "Chop len (Daily)")
 chopThreshTrend   = input.float(38 , "Chop < → Trend", step=0.5)
@@ -136,30 +145,31 @@ shortSignal = ((not useDailyTrendChop) or bearTrendDaily) and
               ((not useATR)            or atrFilter)      and
               ((not useCandlePatterns) or bearPattern)
 
-// ───────── 6.  Состояние для симуляции ───────────────────────────────
+// ───────── 6.  Переменные состояния ──────────────────────────────────
 var bool   waiting  = false
 var bool   waitLong = false
 var int    waitBar  = na
 var float  waitPx   = na
-var float  qty      = na
+//var int  waitSLP   = na
+var string orderId  = ""
 var int    lastExit = na
-var int    pos      = 0
-var float  entryPrice = na
-var float  slPrice = na
-var float  tpPrice = na
 
 var color  barClr = na
 barClr := na
+prevPos = nz(strategy.position_size[1], 0)
 
 // ───────── 7.  Расчёт qty по риску ───────────────────────────────────
 calcQty(price, slPerc)=>
-    riskUSD = equity * riskPerc / 100
+    riskUSD = strategy.equity * riskPerc / 100
     stopUSD = price * slPerc / 100
     qtyRisk = riskUSD / stopUSD
-    math.max(math.round(qtyRisk/qtyStep)*qtyStep, qtyStep)
+    qtyMax  = (strategy.equity * 0.95) / price
+    qty     = math.min(qtyRisk, qtyMax)
+    math.max(math.round(qty/qtyStep)*qtyStep, qtyStep)
 
 // ───────── 8.  Отмена просроченных лимиток ───────────────────────────
-if waiting and pos==0 and (bar_index - waitBar) >= entryTimeout
+if waiting and strategy.position_size==0 and (bar_index - waitBar) >= entryTimeout
+    strategy.cancel(orderId)
     waiting := false
     label.new(bar_index, high, "Cancel",
               xloc=xloc.bar_index, yloc=yloc.price,
@@ -167,16 +177,20 @@ if waiting and pos==0 and (bar_index - waitBar) >= entryTimeout
               color=color.orange, textcolor=color.white)
     barClr := color.orange
 
-// ───────── 9.  Создание новой лимит‑заявки ───────────────────────────
+// ───────── 9.  Постановка новой лимит‑заявки ─────────────────────────
 coolReady = na(lastExit) or (bar_index - lastExit) >= cooldownBars
-if pos==0 and not waiting and coolReady and (longSignal or shortSignal)
+if strategy.position_size==0 and not waiting and coolReady and (longSignal or shortSignal)
     waitLong := longSignal
     waitPx   := open
     waitBar  := bar_index
     slPerc   = math.max(baseSL, coefA + coefB * atrNow)
+    orderId  := (waitLong ? "LIML_" : "LIMS_") + str.tostring(bar_index)
     qty      = calcQty(waitPx, slPerc)
+
+    strategy.entry(orderId, waitLong?strategy.long:strategy.short, qty=qty, limit=waitPx)
     waiting := true
 
+    // ► ALERT: лимит‑ордер создан
     sideTxt = waitLong ? "LONG" : "SHORT"
     alert("LIMIT-"+sideTxt+" | "+syminfo.ticker+
           " | L "+str.tostring(waitPx,format.price),
@@ -189,48 +203,56 @@ if pos==0 and not waiting and coolReady and (longSignal or shortSignal)
               style=waitLong?label.style_label_up:label.style_label_down,
               size=size.tiny, color=clr, textcolor=color.white)
     barClr := clr
+    
+// ───────── 10.  Позиция открылась ────────────────────────────────────
+if strategy.position_size!=0 and prevPos==0
+    waiting := false
+    bool longPos = strategy.position_size > 0
 
-// ───────── 10.  Проверка исполнения лимита ───────────────────────────
-if waiting and pos==0
-    bool filled = (waitLong and low <= waitPx) or (not waitLong and high >= waitPx)
-    if filled
-        waiting := false
-        pos := waitLong ? 1 : -1
-        entryPrice := waitPx
-        slPerc = math.max(baseSL, coefA + coefB * atrNow)
-        tpMultCur = waitLong ? tpMultLong : tpMultShort
-        tpPerc  = slPerc * tpMultCur
-        slPrice := waitLong ? entryPrice*(1 - slPerc/100)
-                             : entryPrice*(1 + slPerc/100)
-        tpPrice := waitLong ? entryPrice*(1 + tpPerc/100)
-                             : entryPrice*(1 - tpPerc/100)
-        alert("ENTRY-"+(waitLong?"LONG":"SHORT")+" | "+syminfo.ticker+
-              " @ "+str.tostring(entryPrice,format.price),
-              alert.freq_once_per_bar)
-        label.new(bar_index, waitLong?low:high,
-             "Entry "+str.tostring(entryPrice,format.price)+
-             ", SL "+fmtPct(slPerc)+"% "+str.tostring(slPrice,format.price)+
-             ", TP "+fmtPct(tpPerc)+"% "+str.tostring(tpPrice,format.price),
-             xloc=xloc.bar_index, yloc=yloc.price,
-             style=waitLong?label.style_label_up:label.style_label_down,
-             size=size.tiny, color=color.lime, textcolor=color.black)
-        barClr := color.lime
+    // ► ALERT: вход выполнен
+    sideTxt = longPos ? "LONG" : "SHORT"
+    alert("ENTRY-"+sideTxt+" | "+syminfo.ticker+
+          " @ "+str.tostring(strategy.position_avg_price,format.price),
+          alert.freq_once_per_bar)
 
-// ───────── 11.  Проверка выхода ─────────────────────────────────────
-if pos != 0
-    bool hitSL = (pos==1 and low <= slPrice) or (pos==-1 and high >= slPrice)
-    bool hitTP = (pos==1 and high >= tpPrice) or (pos==-1 and low <= tpPrice)
-    if hitSL or hitTP
-        exitPrice = hitSL ? slPrice : tpPrice
-        tag = hitSL ? "SL" : "TP"
-        clr = hitSL ? color.maroon : color.aqua
-        label.new(bar_index, high, tag+" "+str.tostring(exitPrice,format.price),
-                  xloc=xloc.bar_index, yloc=yloc.price,
-                  style=label.style_label_down, size=size.tiny,
-                  color=clr, textcolor=color.white)
-        barClr := clr
-        lastExit := bar_index
-        pos := 0
+    entryPrice = strategy.position_avg_price
+    slPerc     = math.max(baseSL, coefA + coefB * atrNow)
+ 
+    tpMultCur  = longPos ? tpMultLong : tpMultShort
+    tpPerc     = slPerc * tpMultCur
+
+    slPrice    = longPos ? entryPrice*(1 - slPerc/100)
+                         : entryPrice*(1 + slPerc/100)
+    tpPrice    = longPos ? entryPrice*(1 + tpPerc/100)
+                         : entryPrice*(1 - tpPerc/100)
+
+    strategy.exit("EXIT", from_entry=orderId, stop=slPrice, limit=tpPrice)
+
+    label.new(bar_index, longPos?low:high,
+         "Entry "+str.tostring(entryPrice,format.price)+
+         ", SL "+fmtPct(slPerc)+"% "+str.tostring(slPrice,format.price)+
+         ", TP "+fmtPct(tpPerc)+"% "+str.tostring(tpPrice,format.price),
+         xloc=xloc.bar_index, yloc=yloc.price,
+         style=longPos?label.style_label_up:label.style_label_down,
+         size=size.tiny, color=color.lime, textcolor=color.black)
+    barClr := color.lime
+
+// ───────── 11.  Выход и cooldown ─────────────────────────────────────
+if strategy.position_size==0 and prevPos!=0
+    idx   = strategy.closedtrades - 1
+    exitP = strategy.closedtrades.exit_price(idx)
+    entryP= strategy.closedtrades.entry_price(idx)
+    bool wasLong = prevPos>0
+    hitSL = (wasLong and exitP < entryP) or (not wasLong and exitP > entryP)
+
+    tag = hitSL?"SL":"TP"
+    clr = hitSL?color.maroon:color.aqua
+    label.new(bar_index, high, tag+" "+str.tostring(exitP,format.price),
+              xloc=xloc.bar_index, yloc=yloc.price,
+              style=label.style_label_down, size=size.tiny,
+              color=clr, textcolor=color.white)
+    barClr := clr
+    lastExit := bar_index
 
 // ───────── 12.  Маркеры сигнала + barcolor ───────────────────────────
 if showMark and longSignal


### PR DESCRIPTION
## Summary
- create `strategy.pine` based on the risk-sicing dynamic-SL strategy
- rewrite `indicator.pine` to simulate the same logic in indicator form

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b524bf9fc8322ac3843a05b7b22a8