### PR TITLE
Update default TP short and Dyn-SL slope

### DIFF
--- a/indicator.pine
+++ b/indicator.pine
@@ -13,11 +13,11 @@ indicator(
 riskPerc        = input.float(1.0 , "Risk per trade (%)", step=0.1)
 atrLen          = input.int  (100 , "ATR length")
 coefA           = input.float(0.84 , "Dyn‑SL: intercept a", step=0.01)
-coefB           = input.float(0.0033,"Dyn‑SL: slope b"     , step=0.0001)
+coefB           = input.float(0.0035,"Dyn‑SL: slope b"     , step=0.0001)
 baseSL          = input.float(1.0 , "Base SL (%)", step=0.1)
 
 tpMultLong      = input.float(4.0 , "TP multiple LONG",  step=0.1)
-tpMultShort     = input.float(1.6 , "TP multiple SHORT", step=0.1)
+tpMultShort     = input.float(2.0 , "TP multiple SHORT", step=0.1)
 
 qtyStep         = input.float(0.001,"Lot step (BTC)", step=0.0001)
 

--- a/strategy.pine
+++ b/strategy.pine
@@ -26,11 +26,11 @@ strategy(
 riskPerc        = input.float(1.0 , "Risk per trade (%)", step=0.1)
 atrLen          = input.int  (100 , "ATR length")
 coefA           = input.float(0.84 , "Dyn‑SL: intercept a", step=0.01)
-coefB           = input.float(0.0033,"Dyn‑SL: slope b"     , step=0.0001)
+coefB           = input.float(0.0035,"Dyn‑SL: slope b"     , step=0.0001)
 baseSL          = input.float(1.0 , "Base SL (%)", step=0.1)
 
 tpMultLong      = input.float(4.0 , "TP multiple LONG",  step=0.1)
-tpMultShort     = input.float(1.6 , "TP multiple SHORT", step=0.1)
+tpMultShort     = input.float(2.0 , "TP multiple SHORT", step=0.1)
 
 qtyStep         = input.float(0.001,"Lot step (BTC)", step=0.0001)
 


### PR DESCRIPTION
## Summary
- bump default Dyn-SL slope `coefB` to 0.0035
- set default TP multiple for short trades to 2.0

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b7985527c83228a07aebad687da44