### PR TITLE
Add entry line in indicator

### DIFF
--- a/indicator.pine
+++ b/indicator.pine
@@ -147,6 +147,7 @@ var int    pos      = 0
 var float  entryPrice = na
 var float  slPrice = na
 var float  tpPrice = na
+var line   entryLine = na
 var line   slLine = na
 var line   tpLine = na
 
@@ -218,6 +219,8 @@ if waiting and pos==0 and bar_index > waitBar
                            color=color.red, style=line.style_dashed)
         tpLine := line.new(bar_index, tpPrice, bar_index, tpPrice,
                            color=color.aqua, style=line.style_dashed)
+        entryLine := line.new(bar_index, entryPrice, bar_index, entryPrice,
+                              color=color.blue, style=line.style_dashed)
         alert("ENTRY-"+(waitLong?"LONG":"SHORT")+" | "+syminfo.ticker+
               " @ "+str.tostring(entryPrice,format.price),
               alert.freq_once_per_bar)
@@ -234,6 +237,7 @@ if waiting and pos==0 and bar_index > waitBar
 if pos != 0
     line.set_xy2(slLine, bar_index, slPrice)
     line.set_xy2(tpLine, bar_index, tpPrice)
+    line.set_xy2(entryLine, bar_index, entryPrice)
     bool hitSL = (pos==1 and low <= slPrice) or (pos==-1 and high >= slPrice)
     bool hitTP = (pos==1 and high >= tpPrice) or (pos==-1 and low <= tpPrice)
     if hitSL or hitTP
@@ -249,6 +253,7 @@ if pos != 0
         pos := 0
         slLine := na
         tpLine := na
+        entryLine := na
 
 // ───────── 12.  Маркеры сигнала + barcolor ───────────────────────────
 if showMark and longSignal


### PR DESCRIPTION
## Summary
- show an entry line along with stop and take profit lines

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_687b7c4235748322a2fa66554dd1cb78